### PR TITLE
Correct missing border in case of intersecting T

### DIFF
--- a/drawer_organizer.scad
+++ b/drawer_organizer.scad
@@ -483,7 +483,7 @@ module connector_t_border(round=true) {
     connector_straight(border=true);
     rotate([0,0,90]) {
         translate([0,0.5*connector_length+border_overhang,0]) {
-            fitting(male=true);
+            fitting(male=true, border=true);
             intersection() {
                 profile(connector_length+border_overhang);
                 skew = border_overhang;


### PR DESCRIPTION
T intersection with border use fitting with no border=true, and make the intersection not the same as the other two branch. This correction make it more correct in my case.